### PR TITLE
Fix compilation on clang

### DIFF
--- a/include/ips2ra/block_permutation.hpp
+++ b/include/ips2ra/block_permutation.hpp
@@ -108,7 +108,7 @@ int Sorter<Cfg>::swapBlock(const diff_t max_off, const int dest_bucket,
             return -1;
         }
         // Check if block needs to be moved
-        new_dest_bucket = classifier_->template classify(begin_[write], level_);
+        new_dest_bucket = classifier_->classify(begin_[write], level_);
     } while (new_dest_bucket == dest_bucket);
 
     // Swap blocks


### PR DESCRIPTION
There are two definitions of the function "classify":
- `bucket_type classify(const value_type&, int)`
- `template <typename Yield> void classify(iterator, iterator, int, Yield&&)`

Only the latter is a template, so specifying `template` here is wrong. This causes compile errors on clang:

> error: no matching member function for call to 'classify'
> ...
> error: assigning to 'int' from incompatible type 'void'

Removing `template` fixes this.