### PR TITLE
Fix UB when computing end_ of stripe during classification

### DIFF
--- a/include/ips2ra/local_classification.hpp
+++ b/include/ips2ra/local_classification.hpp
@@ -109,9 +109,12 @@ void Sorter<Cfg>::parallelClassification() {
     const auto my_begin =
             begin_ + Cfg::alignToNextBlock(my_id_ * elements_per_thread + 0.5);
     const auto my_end = [&] {
-        auto e = begin_ + Cfg::alignToNextBlock((my_id_ + 1) * elements_per_thread + 0.5);
-        e = end_ < e ? end_ : e;
-        return e;
+        const auto size = end_ - begin_;
+        const auto e = Cfg::alignToNextBlock((my_id_ + 1) * elements_per_thread + 0.5);
+        if (size < e) {
+          return end_;
+        }
+        return begin_ + e;
     }();
 
     local_.first_block = my_begin - begin_;


### PR DESCRIPTION
Same as the [PR](https://github.com/ips4o/ips4o/pull/6) in the ips4o repo